### PR TITLE
Update download URL and version

### DIFF
--- a/.milk.yml
+++ b/.milk.yml
@@ -7,9 +7,11 @@ changelog_format: json
 
 # Get Version
 version: "{{ register_changelog.json['stable_versions'][0] }}"
+# Scrap trailing number
+version_short: "{{ version | regex_replace('^([0-9]+\\.[0-9]+)\\..*$', '\\1') }}"
 
 # Download URL
-url: "https://www.archimatetool.com/downloads/archi-5.php?/{{ version }}/Archi-Win64-Setup-{{ version }}.exe"
+url: "https://www.archimatetool.com/downloads/archi/{{ version_short }}/Archi-Win64-Setup-{{ version }}.exe"
 
 searchreplace:
   "tools/chocolateyinstall.ps1":

--- a/package/archi.nuspec
+++ b/package/archi.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>archi</id>
-    <version>5.2.0.1</version>
+    <version>5.6.0</version>
     <title>Archi, The Free ArchiMate Modelling Tool</title>
     <authors>PhillipBeauvoir</authors>
     <owners>Open Circle AG, sbaerlocher, jlruizmlg</owners>

--- a/package/tools/chocolateyinstall.ps1
+++ b/package/tools/chocolateyinstall.ps1
@@ -2,10 +2,10 @@ $ErrorActionPreference = 'Stop';
 $PackageParameters = Get-PackageParameters
 
 $toolsDir = "$(Split-Path -Parent $MyInvocation.MyCommand.Definition)"
-$urlPackage = 'https://www.archimatetool.com/downloads/archi-5.php?/5.2.0/Archi-Win64-Setup-5.2.0.exe'
-$checksumPackage = 'b8bb4409dcbc70a67cb9fefc77226bb8893957ebdc3f9af07219cbf5fdcaa478c2490ca90941c9a789fa3a4d1488561101e247204a35131dc0b22460edddf20f'
-$urlPackage64 = 'https://www.archimatetool.com/downloads/archi-5.php?/5.2.0/Archi-Win64-Setup-5.2.0.exe'
-$checksumPackage64 = 'b8bb4409dcbc70a67cb9fefc77226bb8893957ebdc3f9af07219cbf5fdcaa478c2490ca90941c9a789fa3a4d1488561101e247204a35131dc0b22460edddf20f'
+$urlPackage = 'https://www.archimatetool.com/downloads/archi/5.6/Archi-Win64-Setup-5.6.0.exe'
+$checksumPackage = '3f59c81ac2b8ba62ce31254b94baf36020813dde91aa02ada4335febcdffc6d83d1b1f34e30a2f838ab419b40533809a993c91630be03535e31d7d0dec7d55e2'
+$urlPackage64 = 'https://www.archimatetool.com/downloads/archi/5.6/Archi-Win64-Setup-5.6.0.exe'
+$checksumPackage64 = '3f59c81ac2b8ba62ce31254b94baf36020813dde91aa02ada4335febcdffc6d83d1b1f34e30a2f838ab419b40533809a993c91630be03535e31d7d0dec7d55e2'
 
 
 $packageArgs = @{


### PR DESCRIPTION
- Fixed URL to download the .exe installer
- Update version in .nuspec
- Update `.milk.yml` to correctly parse version and update URL

See Issue #8 